### PR TITLE
NEW Protect Google Maps controls from breaking

### DIFF
--- a/_base.images.scss
+++ b/_base.images.scss
@@ -17,13 +17,13 @@ img{
 
 
 
-
-
 /**
- * If a `width` and/or `height` attribute have been explicitly defined, let’s
- * not make the image fluid.
+ * 1. Google Maps breaks if max-width: 100%, use their selector to avoid this
+ * 2. If a `width` and/or `height` attribute have been explicitly defined, let’s
+ *    not make the image fluid.
  */
-img[width],
-img[height] {
+.gm-style, /* [1] */
+img[width], /* [2] */
+img[height]  /* [2] */ {
     max-width: none;
 }


### PR DESCRIPTION
`img { max-width: 100% }` breaks the navigation elements on Google Maps JS API V3.

Google Maps adds a wrapper element with the class `gs-map` so we can hook into this to protect this from happening

Fixes #2
